### PR TITLE
Various small changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*.log
+
+/fks/linter/__pycache__/
+/test/*.pdf
+/test/*.aux
+/test/*.out

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
     git clone https://github.com/fykosak/fks-linter.git
     cd fks-linter
-    ./fks-linter <file-to-check
+    ./fks-linter file-to-check
 
 # Design
 

--- a/fks-linter
+++ b/fks-linter
@@ -13,5 +13,6 @@ if __name__ == '__main__':
     EqIndentation(l, p, '    ')
     TrailingWhitespace(l, p)
 
-    p.parse(sys.stdin)
+    inf = open(sys.argv[1])
+    p.parse(inf)
 

--- a/fks/linter/__init__.py
+++ b/fks/linter/__init__.py
@@ -54,7 +54,7 @@ class Parser:
         self.context = Context()
 
         for line in stream:
-            line = line[:-1] # TODO CRLF
+            line = line[:-1]
 
             self.state = self.STATE_TEXT
             self.context.lineno += 1

--- a/test/test.tex
+++ b/test/test.tex
@@ -1,0 +1,22 @@
+\documentclass{fksbase}
+\begin{document}
+
+\eq{pV=nRT}
+
+\eq{
+pV=nRT
+}
+
+\eq{
+	pV=nRT
+}
+
+\eq{
+ pV=nRT
+}
+
+\eq{
+    pV=nRT
+}
+
+\end{document}


### PR DESCRIPTION
- solved the problem of differing eoln groups by changing the input method from stdin to file open(); apparently, its default mode is "universal newlines" which autoconverts the platform-specific eoln group to '\n' on input
- added a simple test file (just for equation indentation)
- added gitignore for cache files and other trash